### PR TITLE
[Fix] Missing dependencies for browser and browser_tabbed projects

### DIFF
--- a/browser/requirements.txt
+++ b/browser/requirements.txt
@@ -1,2 +1,3 @@
 PyQt5>=5.6
+PyQtWebEngine
 sip

--- a/browser_tabbed/requirements.txt
+++ b/browser_tabbed/requirements.txt
@@ -1,2 +1,3 @@
 PyQt5>=5.6
+PyQtWebEngine
 sip


### PR DESCRIPTION
Tried to run these projects, discovered PyQtWebEngine needed to be installed to get them going.