### PR TITLE
docs: fix simple typo, neccessary -> necessary

### DIFF
--- a/wordprocessor/wordprocessor.py
+++ b/wordprocessor/wordprocessor.py
@@ -277,7 +277,7 @@ class MainWindow(QMainWindow):
 
     def update_format(self):
         """
-        Update the font format toolbar/actions when a new text selection is made. This is neccessary to keep
+        Update the font format toolbar/actions when a new text selection is made. This is necessary to keep
         toolbars/etc. in sync with the current edit state.
         :return:
         """


### PR DESCRIPTION
There is a small typo in wordprocessor/wordprocessor.py.

Should read `necessary` rather than `neccessary`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md