### PR TITLE
Fixed file save bug

### DIFF
--- a/notepad/notepad.py
+++ b/notepad/notepad.py
@@ -123,7 +123,7 @@ class MainWindow(QMainWindow):
         dlg.show()
 
     def file_open(self):
-        path, _ = QFileDialog.getOpenFileName(self, "Open file", "", "Text documents (*.txt);All files (*.*)")
+        path, _ = QFileDialog.getOpenFileName(self, "Open file", "", "Text documents (*.txt);;All files (*.*)")
 
         if path:
             try:
@@ -146,7 +146,7 @@ class MainWindow(QMainWindow):
         self._save_to_path(self.path)
 
     def file_saveas(self):
-        path, _ = QFileDialog.getSaveFileName(self, "Save file", "", "Text documents (*.txt);All files (*.*)")
+        path, _ = QFileDialog.getSaveFileName(self, "Save file", "", "Text documents (*.txt);;All files (*.*)")
 
         if not path:
             # If dialog is cancelled, will return ''


### PR DESCRIPTION
In the previous code, the file will be saved as `filename.txt);All`

Since multiple filters are separated with two semicolons not one;